### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "author": "hightouch",
     "dependencies": {
         "dsteem": "^0.8.7",
-        "event-stream": "^3.3.4",
+        "event-stream": "3.3.4",
         "express": "^4.16.2",
         "mssql": "^4.2.1",
         "mysql": "^2.16.0",


### PR DESCRIPTION
Event stream a été hacké, ne met pas "^", 3.3.4 c'est la dernière version safe.